### PR TITLE
kotlin: Bump 'foojay-resolver-convention' plugin to enable building with Gradle 9

### DIFF
--- a/kotlin/settings.gradle.kts
+++ b/kotlin/settings.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 rootProject.name = "Supermarket-TestDesign-Kata"


### PR DESCRIPTION
The current 0.8.0 fails to build due to a deprecated vendor spec in the plugin. See https://github.com/gradle/foojay-toolchains/blob/main/CHANGELOG.md#100---2025-05-19

